### PR TITLE
gh-41: fix regression test counting in workflow

### DIFF
--- a/.github/workflows/run-regression-tests-bot.yml
+++ b/.github/workflows/run-regression-tests-bot.yml
@@ -78,39 +78,38 @@ jobs:
         echo "📊 Found $TOTAL_TESTS regression tests"
         echo ""
         
-        # Initialize counters
-        PASSED=0
-        FAILED=0
-        FAILED_TESTS=""
+        # Initialize counters and files
+        echo "0" > /tmp/passed_count
+        echo "0" > /tmp/failed_count
+        echo "" > /tmp/failed_tests
         
         # Run each test file
-        find "$REGRESSION_DIR" -name "*.thorn" -type f | sort | while read -r test_file; do
+        for test_file in $(find "$REGRESSION_DIR" -name "*.thorn" -type f | sort); do
           test_name=$(basename "$test_file")
           echo "Running: $test_name"
           
           # Run the test and capture output
           if java com.thorn.Thorn "$test_file" > /tmp/test_output.txt 2>&1; then
             echo "  ✅ PASSED"
+            PASSED=$(cat /tmp/passed_count)
             PASSED=$((PASSED + 1))
+            echo "$PASSED" > /tmp/passed_count
           else
             echo "  ❌ FAILED"
             echo "  Output:"
             cat /tmp/test_output.txt | sed 's/^/    /'
+            FAILED=$(cat /tmp/failed_count)
             FAILED=$((FAILED + 1))
-            FAILED_TESTS="$FAILED_TESTS\n- $test_name"
+            echo "$FAILED" > /tmp/failed_count
+            echo "- $test_name" >> /tmp/failed_tests
           fi
           echo ""
-          
-          # Save counters to file since we're in a subshell
-          echo "$PASSED" > /tmp/passed_count
-          echo "$FAILED" > /tmp/failed_count
-          echo -e "$FAILED_TESTS" > /tmp/failed_tests
         done
         
-        # Read counters from files
-        PASSED=$(cat /tmp/passed_count 2>/dev/null || echo 0)
-        FAILED=$(cat /tmp/failed_count 2>/dev/null || echo 0)
-        FAILED_TESTS=$(cat /tmp/failed_tests 2>/dev/null || echo "")
+        # Read final counters from files
+        PASSED=$(cat /tmp/passed_count)
+        FAILED=$(cat /tmp/failed_count)
+        FAILED_TESTS=$(cat /tmp/failed_tests | grep -v '^$' | tr '\n' ' ')
         
         # Summary
         echo "========================================"
@@ -122,7 +121,8 @@ jobs:
         
         if [ "$FAILED" -gt 0 ]; then
           echo ""
-          echo "Failed tests:$FAILED_TESTS"
+          echo "Failed tests:"
+          cat /tmp/failed_tests | grep -v '^$'
           echo "status=failed" >> $GITHUB_OUTPUT
           echo "failed_count=$FAILED" >> $GITHUB_OUTPUT
           echo "passed_count=$PASSED" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Fix regression test counting that was showing "0 of 0" tests
- Replace while-read loop (subshell) with for loop to preserve variable values
- Properly track passed/failed counts using temporary files

## Problem
The regression test workflow was reporting "0 of 0" tests even though tests exist in `tests/regression/`. This was because the `while read` loop runs in a subshell, so variable modifications inside weren't visible outside.

## Solution
- Changed from `while read` to `for` loop to avoid subshell issues
- Initialize counter files at the start
- Read/write counters to temporary files within the loop
- Read final values after the loop completes

## Test plan
- [x] Tested the counting logic locally with sample tests
- [x] Verified counts are properly tracked (3 passed, 0 failed)
- [x] Workflow should now correctly report test results